### PR TITLE
Remove SSLv3 to cover for POODLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 2.0.x
+
+* Remove SSLv3 to cover for POODLE
+* Fix tcp-request/reqadd ordering to remove warnings
+* Log to syslog using unix socket #3
+
 ## Version 2.0.0
 
 * Throttling

--- a/haproxy/templates/haproxy.cfg
+++ b/haproxy/templates/haproxy.cfg
@@ -1,7 +1,7 @@
 {% from "haproxy/map.jinja" import haproxy, haproxy_role with context %}
 
 global
-    log         127.0.0.1 local0 {{ haproxy.loglevel }}
+    log         /dev/log local0 {{ haproxy.loglevel }}
 
     chroot      /var/lib/haproxy
     pidfile     /var/run/haproxy.pid
@@ -51,22 +51,24 @@ defaults
 
     frontend http
         bind *:{{haproxy.this.http_port}}
-        reqadd X-Forwarded-Proto:\ http
         capture request header X-Request-ID len 64
         capture request header User-Agent len 200
 
         {% include 'haproxy/templates/snippet-throttling-frontend.cfg' with context %}
+
+        reqadd X-Forwarded-Proto:\ http
 
         redirect scheme https
 
 
     frontend https
-        bind *:{{haproxy.this.https_port}} ssl crt /etc/ssl/certs/ssl.pem ciphers {{haproxy.this.ciphers}}
-        reqadd X-Forwarded-Proto:\ https
+        bind *:{{haproxy.this.https_port}} ssl crt /etc/ssl/certs/ssl.pem ciphers {{haproxy.this.ciphers}} no-sslv3
         capture request header X-Request-ID len 64
         capture request header User-Agent len 200
 
         {% include 'haproxy/templates/snippet-throttling-frontend.cfg' with context %}
+
+        reqadd X-Forwarded-Proto:\ https
 
         redirect scheme https if !{ ssl_fc }
         default_backend             {{haproxy_role}}
@@ -75,11 +77,12 @@ defaults
 
     frontend http
         bind *:{{haproxy.this.http_port}}
-        reqadd X-Forwarded-Proto:\ http
         capture request header X-Request-ID len 64
         capture request header User-Agent len 200
 
         {% include 'haproxy/templates/snippet-throttling-frontend.cfg' with context %}
+
+        reqadd X-Forwarded-Proto:\ http
 
         default_backend             {{haproxy_role}}
 


### PR DESCRIPTION
- Remove SSLv3 to cover for POODLE
- Fix order of tcp-request/reqadd (warning messages)
- Log to /dev/log socket as UDP is too short for long messages
