### PR TITLE
Allow protection of backend via basic auth acl

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,23 @@ Note that all throttling is happening on layer 4 (transport - tcp).
 Additionally we also protect from slowloris type attack. By waiting max 5s for connection and 5s for http-request.
 It might impact big POST requests.
 
+Basic Auth support
+------------------
+
+It is possible to lock the haproxy instance down via Basic Auth, for example
+for non-public instances of a site.
+
+This can be done by setting the following pillar values in your haproxy role::
+
+    haproxy.haproxy_role.basic_auth_enabled: True
+    haproxy.haproxy_role.basic_auth_user: 'admin'
+    haproxy.haproxy_role.basic_auth_password: '$5$boguscryptpasswordstringblahblah'
+
+The value of basic_auth_password should be a string parsable by crypt(3). The
+'mkpasswd' tool (in 'whois' package on Ubuntu) can be useful for this task::
+
+    mkpasswd -m sha-256
+
 
 salt mine configuration
 -----------------------

--- a/haproxy/map.jinja
+++ b/haproxy/map.jinja
@@ -8,7 +8,7 @@
         'Debian': {
           'basic_auth_enable': False,
           'basic_auth_user': 'admin',
-          'basic_auth_password': 'INVALID_USE_MKPASSWD_TO_CREATE',
+          'basic_auth_password': 'UNSET',
           'downstream_port': 80,
           'throttling': False,
           'throttling_src_conn_cur': 50,

--- a/haproxy/map.jinja
+++ b/haproxy/map.jinja
@@ -6,6 +6,9 @@
       'role': haproxy_role,
       'this': salt['grains.filter_by']({
         'Debian': {
+          'basic_auth_enable': False,
+          'basic_auth_user': 'admin',
+          'basic_auth_password': 'INVALID_USE_MKPASSWD_TO_CREATE',
           'downstream_port': 80,
           'throttling': False,
           'throttling_src_conn_cur': 50,

--- a/haproxy/templates/haproxy.cfg
+++ b/haproxy/templates/haproxy.cfg
@@ -15,7 +15,10 @@ global
 
     # safety first
     tune.ssl.default-dh-param 2048
-
+{% if haproxy.this.basic_auth_enable %}
+userlist siteAccessRestriction
+  user {{haproxy.this.basic_auth_user}} password {{haproxy.this.basic_auth_password}}
+{% endif %}
 
 defaults
     log                     global
@@ -111,6 +114,11 @@ backend {{haproxy_role}}
     {% for host, ips in salt['mine.get']('roles:'+haproxy_role, 'network.ip_addrs', 'grain').iteritems() %}
     server       {{haproxy_role}}{{loop.index}} {{ips[0]}}:{{haproxy.this.downstream_port}} check
     {% endfor %}
+
+{% if haproxy.this.basic_auth_enable %}
+    acl AuthOkay_Site http_auth(siteAccessRestriction)
+      http-request auth realm SiteProtected if !AuthOkay_Site
+{% endif %}
 
 #########
 # debug #


### PR DESCRIPTION
This is a simple implementation of basic auth on the haproxy balancer
to allow us to block sites entirely with a username/password. This is
commonly done on preview/staging environments to protect from accidental
use by the public, without the need for firewall restrictions.

The default is for it to be 'off', turn on as needed.

This has been implemented as per: <http://serverfault.com/questions/239749/possible-to-add-basic-http-access-authentication-via-haproxy>

... which in turn references <https://nbevans.wordpress.com/2011/03/03/cultural-learnings-of-ha-proxy-for-make-benefit>